### PR TITLE
Fix property name in MCP patch response

### DIFF
--- a/src/mcp/mcp.controller.ts
+++ b/src/mcp/mcp.controller.ts
@@ -15,7 +15,7 @@ export class MCPController {
   async patchContext(@Body() body: { userId: number; isActive: boolean }) {
     const { userId, isActive } = body;
     const user = await this.userService.updateUser(userId, { isActive });
-    return { udpated: user };
+    return { updated: user };
   }
 
   @Post("commands")


### PR DESCRIPTION
## Summary
- fix spelling for `updated` key in MCP patch endpoint

## Testing
- `npm run build` *(fails: Cannot find module '@google/generative-ai' ...)*

------
https://chatgpt.com/codex/tasks/task_e_685311e536ac8321867645383b37b03a